### PR TITLE
add automated pytest run when pr into main is opened

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,21 +18,22 @@ jobs:
         with:
           python-version: "3.13"
 
-      - name: Install uv
-        uses: astral-sh/setup-uv@v6
+      - name: Install dependencies
+        run: |
+          pip install .
 
       - name: Install dependencies
         run: |
-          uv sync --group dev
+          pip install pytest pytest-cov
 
       - name: Markdown formatting check
         run: |
-          uv run mdformat --check . --exclude '.github/instructions/**'
+          mdformat --check . --exclude '.github/instructions/**'
 
       - name: Check build
         run: |
-          uv run mkdocs build
+          mkdocs build
 
       - name: Run tests
         run: |
-          uv run pytest
+          pytest


### PR DESCRIPTION
Add pytest to ci. I tried a few ways, but ultimately chose to install pytest as an added step. Incorporating uv and the pyproject.toml to build the ci environment was messy. CLOSES #96 