### PR TITLE
Added function 'getZscore'

### DIFF
--- a/src/inland_consequences/coastal/_pfracoastal_lib.py
+++ b/src/inland_consequences/coastal/_pfracoastal_lib.py
@@ -40,5 +40,5 @@ class _PFRACoastal_Lib:
     # 	main()
     # calls:
     #	NULL
-    def getZscore(x: float, mean_data: float, sd_data: float) -> float:
+    def getZscore(self, x: float, mean_data: float, sd_data: float) -> float:
         return (x - mean_data) / sd_data

--- a/src/inland_consequences/coastal/tests/test_getZscore.py
+++ b/src/inland_consequences/coastal/tests/test_getZscore.py
@@ -1,0 +1,12 @@
+from inland_consequences.coastal import _pfracoastal_lib
+
+def test_getZscore():
+    lib = _pfracoastal_lib._PFRACoastal_Lib()
+    
+    test_x = 150.0
+    test_mean = 100.0
+    test_sd = 10.0
+    
+    ret = lib.getZscore(x=test_x, mean_data = test_mean, sd_data=test_sd)
+    
+    assert ret == 5.0


### PR DESCRIPTION
Converted function getZscore from R to Python and added it to _pfracoastal_lib.py.

The mathematical expression to calculate the z-score is the same between the R and Python versions of the function, but unknown if the results will be exactly the same, so this will need to be tested going forward.

Was unable to determine the type hints that should be used from the R code, so went with `float` for all.